### PR TITLE
Added tm1_dimension_subset_to_set function

### DIFF
--- a/mdxpy/mdx.py
+++ b/mdxpy/mdx.py
@@ -181,6 +181,10 @@ class MdxHierarchySet:
         return Tm1SubsetToSetHierarchySet(dimension, hierarchy, subset)
 
     @staticmethod
+    def tm1_dimension_subset_to_set(dimension: str, subset: str) -> 'MdxHierarchySet':
+        return Tm1SubsetToSetHierarchySet(dimension, dimension, subset)
+
+    @staticmethod
     def all_consolidations(dimension: str, hierarchy: str = None) -> 'MdxHierarchySet':
         return AllCElementsHierarchySet(dimension, hierarchy)
 

--- a/test.py
+++ b/test.py
@@ -153,6 +153,12 @@ class Test(unittest.TestCase):
             '{TM1SUBSETTOSET([DIMENSION].[HIERARCHY],"Default")}',
             hierarchy_set.to_mdx())
 
+    def test_mdx_hierarchy_set_tm1_dimension_subset_to_set(self):
+        hierarchy_set = MdxHierarchySet.tm1_dimension_subset_to_set("Dimension", "Default")
+        self.assertEqual(
+            '{TM1SUBSETTOSET([DIMENSION].[DIMENSION],"Default")}',
+            hierarchy_set.to_mdx())
+
     def test_mdx_hierarchy_set_all_consolidations(self):
         hierarchy_set = MdxHierarchySet.all_consolidations("Dimension")
         self.assertEqual(


### PR DESCRIPTION
tm1_dimension_subset_to_set  will act the same as tm1_subset_to_set, but without the need for the hierarchy argument.